### PR TITLE
removed 'powered by' at end of emails

### DIFF
--- a/mails/en/newsletter_conf.html
+++ b/mails/en/newsletter_conf.html
@@ -101,7 +101,7 @@
 						</tr>
 						<tr>
 							<td class="footer" style="border-top:4px solid #333333;padding:7px 0">
-								<span><a href="{shop_url}" style="color:#337ff1">{shop_name}</a> powered by <a href="https://thirtybees.com/" style="color:#337ff1">thirty bees&trade;</a></span>
+								<span><a href="{shop_url}" style="color:#337ff1">{shop_name}</a></span>
 							</td>
 						</tr>
 					</table>

--- a/mails/en/newsletter_conf.txt
+++ b/mails/en/newsletter_conf.txt
@@ -5,6 +5,4 @@ Hi,
 
 THANK YOU FOR SUBSCRIBING TO OUR NEWSLETTER. 
 
-{shop_name} [{shop_url}] powered by
-thirty bees(tm) [https://thirtybees.com/] 
-
+{shop_name} [{shop_url}]

--- a/mails/en/newsletter_verif.html
+++ b/mails/en/newsletter_verif.html
@@ -101,7 +101,7 @@
 						</tr>
 						<tr>
 							<td class="footer" style="border-top:4px solid #333333;padding:7px 0">
-								<span><a href="{shop_url}" style="color:#337ff1">{shop_name}</a> powered by <a href="https://thirtybees.com/" style="color:#337ff1">thirty bees&trade;</a></span>
+								<span><a href="{shop_url}" style="color:#337ff1">{shop_name}</a></span>
 							</td>
 						</tr>
 					</table>

--- a/mails/en/newsletter_verif.txt
+++ b/mails/en/newsletter_verif.txt
@@ -8,6 +8,4 @@ request by clicking the link below :
 
 {verif_url} [{verif_url}] 		 
 
-{shop_name} [{shop_url}] powered by
-thirty bees(tm) [https://thirtybees.com/] 
-
+{shop_name} [{shop_url}]

--- a/mails/en/newsletter_voucher.html
+++ b/mails/en/newsletter_voucher.html
@@ -102,7 +102,7 @@
 						</tr>
 						<tr>
 							<td class="footer" style="border-top:4px solid #333333;padding:7px 0">
-								<span><a href="{shop_url}" style="color:#337ff1">{shop_name}</a> powered by <a href="https://thirtybees.com/" style="color:#337ff1">thirty bees&trade;</a></span>
+								<span><a href="{shop_url}" style="color:#337ff1">{shop_name}</a></span>
 							</td>
 						</tr>
 					</table>

--- a/mails/en/newsletter_voucher.txt
+++ b/mails/en/newsletter_voucher.txt
@@ -6,6 +6,4 @@ Hi,
 Regarding your newsletter subscription, we are pleased to offer
 you the following voucher: {discount} 
 
-{shop_name} [{shop_url}] powered by
-thirty bees(tm) [https://thirtybees.com/] 
-
+{shop_name} [{shop_url}]


### PR DESCRIPTION
Removed to be more consistent with newer versions of thirty bees